### PR TITLE
MAT-3281: Hiding madie-auth and madie-editor mount points

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madie/root-config",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "scripts": {
     "start": "webpack serve --port 9000 --env isLocal",
     "lint": "eslint src --ext js,ts,tsx",

--- a/src/ApplicationConfig.ts
+++ b/src/ApplicationConfig.ts
@@ -7,7 +7,7 @@ export interface ApplicationProps {
 export default interface ApplicationConfig
   extends RegisterApplicationConfig<ApplicationProps> {
   app: () => Promise<LifeCycles<ApplicationProps>>;
-  customProps?: {
+  customProps: {
     domElementGetter: () => HTMLElement | null;
   };
 }

--- a/src/auth-config.test.ts
+++ b/src/auth-config.test.ts
@@ -15,7 +15,16 @@ describe("Auth Config", () => {
       name: "@madie/madie-auth",
       app: expect.any(Function),
       activeWhen: ["/"],
+      customProps: {
+        domElementGetter: expect.any(Function),
+      },
     });
+  });
+
+  it("should have a domElementGetter to locate the #madie-auth element", () => {
+    document.getElementById = jest.fn(() => null);
+    expect(authConfig.customProps.domElementGetter()).toBeNull();
+    expect(document.getElementById).toHaveBeenCalledWith("madie-auth");
   });
 
   it("should have a module loader which loads the madie-auth app", async () => {

--- a/src/auth-config.ts
+++ b/src/auth-config.ts
@@ -4,6 +4,10 @@ const config: ApplicationConfig = {
   name: "@madie/madie-auth",
   app: () => System.import("@madie/madie-auth"),
   activeWhen: ["/"],
+  customProps: {
+    domElementGetter: (): HTMLElement | null =>
+      document.getElementById("madie-auth"),
+  },
 };
 
 export default config;

--- a/src/editor-config.test.ts
+++ b/src/editor-config.test.ts
@@ -15,7 +15,16 @@ describe("Editor Config", () => {
       name: "@madie/madie-editor",
       app: expect.any(Function),
       activeWhen: ["/"],
+      customProps: {
+        domElementGetter: expect.any(Function),
+      },
     });
+  });
+
+  it("should have a domElementGetter to locate the #madie-editor element", () => {
+    document.getElementById = jest.fn(() => null);
+    expect(editorConfig.customProps.domElementGetter()).toBeNull();
+    expect(document.getElementById).toHaveBeenCalledWith("madie-editor");
   });
 
   it("should have a module loader which loads the madie-editor app", async () => {

--- a/src/editor-config.ts
+++ b/src/editor-config.ts
@@ -4,6 +4,10 @@ const config: ApplicationConfig = {
   name: "@madie/madie-editor",
   app: () => System.import("@madie/madie-editor"),
   activeWhen: ["/"],
+  customProps: {
+    domElementGetter: (): HTMLElement | null =>
+      document.getElementById("madie-editor"),
+  },
 };
 
 export default config;

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -71,6 +71,10 @@
     You need to enable JavaScript to run this app.
   </noscript>
   <main id="main"></main>
+  <div id="application-registry" style="display:none;">
+    <div id="madie-editor"></div>
+    <div id="madie-auth"></div>
+  </div>
   <script>
     System.import('@madie/root-config');
   </script>

--- a/src/layout-config.test.ts
+++ b/src/layout-config.test.ts
@@ -24,6 +24,7 @@ describe("Layout Config", () => {
   it("should have a domElementGetter to locate the #main element", () => {
     document.getElementById = jest.fn(() => null);
     expect(layoutConfig.customProps.domElementGetter()).toBeNull();
+    expect(document.getElementById).toHaveBeenCalledWith("main");
   });
 
   it("should have a module loader which loads the madie-layout app", async () => {


### PR DESCRIPTION
MAT-3281: Now hiding the madie-auth and madie-editor mounts in a hidden div (for debugging purposes). Also preparing for NPM publish