### PR TITLE
Register components app with single-spa root

### DIFF
--- a/local-dev-env/hosted-importmap.json
+++ b/local-dev-env/hosted-importmap.json
@@ -4,6 +4,7 @@
     "@madie/madie-layout": "//localhost:8500/madie-madie-layout.js",
     "@madie/madie-editor": "//localhost:8501/madie-madie-editor.js",
     "@madie/madie-auth": "//localhost:8502/madie-madie-auth.js",
-    "@madie/madie-public": "//localhost:8503/madie-madie-public.js"
+    "@madie/madie-public": "//localhost:8503/madie-madie-public.js",
+    "@madie/madie-components": "//localhost:8504/madie-madie-components.js"
   }
 }

--- a/local-dev-env/importmap.json
+++ b/local-dev-env/importmap.json
@@ -2,8 +2,9 @@
   "imports": {
     "@madie/root-config": "//localhost:9000/madie-root-config.js",
     "@madie/madie-layout": "//localhost:8500/madie-madie-layout.js",
-    "@madie/madie-editor": "/madie-editor/madie-madie-editor.js",
-    "@madie/madie-auth": "/madie-auth/madie-madie-auth.js",
-    "@madie/madie-public": "//localhost:8503/madie-madie-public.js"
+    "@madie/madie-editor": "//localhost:8501/madie-madie-editor.js",
+    "@madie/madie-auth": "//localhost:8502/madie-madie-auth.js",
+    "@madie/madie-public": "//localhost:8503/madie-madie-public.js",
+    "@madie/madie-components": "//localhost:8504/madie-madie-components.js"
   }
 }

--- a/src/components-config.test.ts
+++ b/src/components-config.test.ts
@@ -1,0 +1,35 @@
+import componentsConfig from "./components-config";
+
+describe("Components Config", () => {
+  const appModuleStub = { success: true };
+  beforeEach(async () => {
+    System.import = jest.fn().mockResolvedValue(appModuleStub);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should contain the expected properties", () => {
+    expect(componentsConfig).toMatchObject({
+      name: "@madie/madie-components",
+      app: expect.any(Function),
+      activeWhen: ["/"],
+      customProps: {
+        domElementGetter: expect.any(Function),
+      },
+    });
+  });
+
+  it("should have a domElementGetter to locate the #madie-components element", () => {
+    document.getElementById = jest.fn(() => null);
+    expect(componentsConfig.customProps.domElementGetter()).toBeNull();
+    expect(document.getElementById).toHaveBeenCalledWith("madie-components");
+  });
+
+  it("should have a module loader which loads the madie-components app", async () => {
+    let result = await componentsConfig.app();
+    expect(result).toBe(appModuleStub);
+    expect(System.import).toHaveBeenCalledWith("@madie/madie-components");
+  });
+});

--- a/src/components-config.ts
+++ b/src/components-config.ts
@@ -1,0 +1,13 @@
+import ApplicationConfig from "./ApplicationConfig";
+
+const config: ApplicationConfig = {
+  name: "@madie/madie-components",
+  app: () => System.import("@madie/madie-components"),
+  activeWhen: ["/"],
+  customProps: {
+    domElementGetter: (): HTMLElement | null =>
+      document.getElementById("madie-components"),
+  },
+};
+
+export default config;

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -72,6 +72,7 @@
     <div id="madie-editor"></div>
     <div id="madie-auth"></div>
     <div id="madie-public"></div>  
+    <div id="madie-components"></div>
   </div>
   <script>
     System.import('@madie/root-config');

--- a/src/madie-root-config.ts
+++ b/src/madie-root-config.ts
@@ -4,11 +4,13 @@ import layoutConfig from "./layout-config";
 import editorConfig from "./editor-config";
 import authConfig from "./auth-config";
 import publicConfig from "./public-config";
+import componentsConfig from "./components-config";
 
 registerApplication<ApplicationProps>(layoutConfig);
 registerApplication<ApplicationProps>(editorConfig);
 registerApplication<ApplicationProps>(authConfig);
 registerApplication<ApplicationProps>(publicConfig);
+registerApplication<ApplicationProps>(componentsConfig);
 
 start({
   urlRerouteOnly: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,6 +48,13 @@ module.exports = (webpackConfigEnv, argv) => {
           publicPath: "/madie-auth",
         },
         {
+          directory: path.join(
+            __dirname,
+            "node_modules/@madie/madie-components/dist/"
+          ),
+          publicPath: "/madie-components",
+        },
+        {
           directory: path.join(__dirname, "local-dev-env"),
           publicPath: "/importmap",
         },


### PR DESCRIPTION
Wire up the Components micro-fontend application to our single-spa root application.

See [MeasureAuthoringTool/madie-componets](https://github.com/MeasureAuthoringTool/madie-components) for more info about the components app.
